### PR TITLE
fix: catch some corner cases

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -70,6 +70,15 @@ def extract_data(unzipped_dir, out_dir):
 
         with open(join(content_sources_dir, f"{source_guid}.json"), "w") as f:
             json.dump(source_attrs, f, indent=4)
+
+        # there might not be a selection in a PDF
+        if "PDFSelection" not in source:
+            continue
+
+        # if there's only one selection in a single PDF,
+        # `source["PDFSelection"]` is a dict and not an array
+        if isinstance(source["PDFSelection"], dict):
+            source["PDFSelection"] = [source["PDFSelection"]]
     
         for quotation in source["PDFSelection"]:
             if "Coding" in quotation:


### PR DESCRIPTION
Thanks for sharing this script, Mark!

While running it on my .qdpx file, I encountered two special cases that I needed to account for:
1. **When a source (PDF) doesn't have any selections/coding**: my guess is that you've filtered those out before coding, I didn't.
2. **When a source only has a single selection:** for example, a single figure is selected, there's the similar issue like you've covered with the `quotation["Coding"]` dict/array check.

Should be pretty straightforward fixes, I hope I didn't miss anything.